### PR TITLE
Check quackability of `other' object before comparing

### DIFF
--- a/lib/haversine/distance.rb
+++ b/lib/haversine/distance.rb
@@ -40,7 +40,11 @@ module Haversine
     alias_method :to_nm, :to_nautical_miles
 
     def <=>(other)
-      great_circle_distance <=> other.great_circle_distance
+      if other.respond_to? :great_circle_distance # it's duck if it quacks
+        great_circle_distance <=> other.great_circle_distance
+      else
+        return nil # spitting out nil when objects are not comparable
+      end
     end
   end
 end


### PR DESCRIPTION
Hi, Kristian! 
I made small changes in `<=>(other)` method to mimic behavior of other types of objects in ruby.
Usually, when both objects in comparison are not actually comparable, the statement will return nil.
That is why these statements return like this:
```ruby
1 == "1"  #=> false
"3" == 3  #=> false
```

But, for object of type `Haversine::Distance`, it throws `NoMethodError`:
```ruby
distance = Haversine.distance(35.61488, 139.5813, 48.85341, 2.3488)
distance == 2  #=> NoMethodError: undefined method `great_circle_distance' for 2:Fixnum
2 == distance  #=> NoMethodError: undefined method `great_circle_distance' for 2:Fixnum
```

The object will behave like other comparable objects in ruby after these changes:
- check if `other` respond to `great_circle_distance` method
- return nil if it's not.

Results:
```ruby
distance = Haversine.distance(35.61488, 139.5813, 48.85341, 2.3488)
distance == 2  #=> false
2 == distance  #=> false
```
