### PR TITLE
Add simplecov to Gemfile and .gemspec that is required in spec_helper.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :development do
   gem "rspec", ">= 2.14.0"
   gem "bundler", ">= 1.3.0"
   gem "jeweler", ">= 1.8.6"
+  gem "simplecov", "~> 0.7", ">= 0.7.1"
 end

--- a/haversine.gemspec
+++ b/haversine.gemspec
@@ -45,15 +45,17 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rspec>.freeze, [">= 2.14.0"])
       s.add_development_dependency(%q<bundler>.freeze, [">= 1.3.0"])
       s.add_development_dependency(%q<jeweler>.freeze, [">= 1.8.6"])
+      s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.7", ">= 0.7.1"])
     else
       s.add_dependency(%q<rspec>.freeze, [">= 2.14.0"])
       s.add_dependency(%q<bundler>.freeze, [">= 1.3.0"])
       s.add_dependency(%q<jeweler>.freeze, [">= 1.8.6"])
+      s.add_dependency(%q<simplecov>.freeze, ["~> 0.7", ">= 0.7.1"])
     end
   else
     s.add_dependency(%q<rspec>.freeze, [">= 2.14.0"])
     s.add_dependency(%q<bundler>.freeze, [">= 1.3.0"])
     s.add_dependency(%q<jeweler>.freeze, [">= 1.8.6"])
+    s.add_dependency(%q<simplecov>.freeze, ["~> 0.7", ">= 0.7.1"])
   end
 end
-


### PR DESCRIPTION
Hi, Kristian! I updated your `Gemfile` and `.gemspec` to use `simplecov` with the latest version (v0.7.1) that was available at the time you add `SimpleCov.start` to `spec/spec_helper.rb`. If I don't add it, I get `LoadError` for `simplecov`.