### PR TITLE
Renew Rspec syntax to use `expect`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "http://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "rspec", ">= 2.14.0"
+  gem "rspec", "~> 3.6", ">= 3.6.0"
   gem "bundler", ">= 1.3.0"
   gem "jeweler", ">= 1.8.6"
 end

--- a/haversine.gemspec
+++ b/haversine.gemspec
@@ -42,18 +42,17 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<rspec>.freeze, [">= 2.14.0"])
+      s.add_development_dependency(%q<rspec>.freeze, ["~> 3.6", ">= 3.6.0"])
       s.add_development_dependency(%q<bundler>.freeze, [">= 1.3.0"])
       s.add_development_dependency(%q<jeweler>.freeze, [">= 1.8.6"])
     else
-      s.add_dependency(%q<rspec>.freeze, [">= 2.14.0"])
+      s.add_dependency(%q<rspec>.freeze, ["~> 3.6", ">= 3.6.0"])
       s.add_dependency(%q<bundler>.freeze, [">= 1.3.0"])
       s.add_dependency(%q<jeweler>.freeze, [">= 1.8.6"])
     end
   else
-    s.add_dependency(%q<rspec>.freeze, [">= 2.14.0"])
+    s.add_dependency(%q<rspec>.freeze, ["~> 3.6", ">= 3.6.0"])
     s.add_dependency(%q<bundler>.freeze, [">= 1.3.0"])
     s.add_dependency(%q<jeweler>.freeze, [">= 1.8.6"])
   end
 end
-

--- a/spec/distance_spec.rb
+++ b/spec/distance_spec.rb
@@ -6,13 +6,13 @@ describe Haversine::Distance do
       it "is true when the great circle distance is equal" do
         dist1 = Haversine::Distance.new(0)
         dist2 = Haversine::Distance.new(0)
-        (dist1 == dist2).should be_true
+        expect(dist1 == dist2).to be(true)
       end
-  
+
       it "is false when the great circle distance is not equal" do
         dist1 = Haversine::Distance.new(0)
         dist2 = Haversine::Distance.new(1)
-        (dist1 == dist2).should be_false
+        expect(dist1 == dist2).to be(false)
       end
     end
   end

--- a/spec/haversine_spec.rb
+++ b/spec/haversine_spec.rb
@@ -3,35 +3,35 @@ require 'spec_helper'
 describe Haversine do
   describe "#self.distance" do
     it "returns Haversine::Distance" do
-      Haversine.distance(0,0,0,0).should be_a(Haversine::Distance)
+      expect(Haversine.distance(0,0,0,0)).to be_a(Haversine::Distance)
     end
-    
+
     it "accepts 4 numbers or 2 arrays as arguments" do
       new_york_city = [40.71427, -74.00597]
       santiago_chile = [-33.42628, -70.56656]
       point_dist = Haversine.distance(new_york_city[0], new_york_city[1], santiago_chile[0], santiago_chile[1])
       array_dist = Haversine.distance(new_york_city, santiago_chile)
-      
-      point_dist.should be_a(Haversine::Distance)
-      array_dist.should be_a(Haversine::Distance)
-      point_dist.to_m.should == array_dist.to_m
+
+      expect(point_dist).to be_a(Haversine::Distance)
+      expect(array_dist).to be_a(Haversine::Distance)
+      expect(point_dist.to_m).to eq(array_dist.to_m)
     end
 
     it "computes nautical mile distances correctly" do
       new_york_city = [40.71427, -74.00597]
       santiago_chile = [-33.42628, -70.56656]
       dist = Haversine.distance(new_york_city, santiago_chile)
-      dist.to_miles.should eq(5123.736179853891)
-      dist.to_nautical_miles.should eq(4452.402874445064)
+      expect(dist.to_miles).to eq(5123.736179853891)
+      expect(dist.to_nautical_miles).to eq(4452.402874445064)
     end
 
     it "calculates the distance between the provided lat/lon pairs" do
-      Haversine.distance(0,0,0,0).to_miles.should == 0
-      round_to(6, Haversine.distance(0,0,0,360).to_miles).should == 0
-      round_to(6, Haversine.distance(0,0,360,0).to_miles).should == 0
+      expect(Haversine.distance(0,0,0,0).to_miles).to eq(0)
+      expect(round_to(6, Haversine.distance(0,0,0,360).to_miles)).to eq(0)
+      expect(round_to(6, Haversine.distance(0,0,360,0).to_miles)).to eq(0)
     end
   end
-  
+
   # Helpers
   def round_to(precision, num)
     (num * 10**precision).round.to_f / 10**precision


### PR DESCRIPTION
Try to use the latest Rspec syntax `expect` because the old one (`should`) is deprecated. You might need to merge my previous PR if you want to test this by running `rspec` as you haven't added `simplecov` to `Gemfile` or `.gemspec`.